### PR TITLE
Fix major regression about deleted text values after a question save

### DIFF
--- a/server/services-impl/src/main/java/it/geosolutions/fra2015/services/BulkModelEntitiesLoader.java
+++ b/server/services-impl/src/main/java/it/geosolutions/fra2015/services/BulkModelEntitiesLoader.java
@@ -180,4 +180,13 @@ public class BulkModelEntitiesLoader {
 		searchCriteria.addFilterEqual("entryItem.entry.question.id", questions);
 		return textNumberDAO.search(searchCriteria);
 	}
+	
+        public List<TextValue> loadTextNumericValues(String iso3, Integer questions) {
+    
+                Search searchCriteria = new Search();
+                searchCriteria.addFilterEqual("country.iso3", iso3);
+                searchCriteria.addFetch("entryItem.entry");
+                searchCriteria.addFilterEqual("entryItem.entry.question.id", questions);
+                return textValueDAO.search(searchCriteria);
+        }
 }

--- a/server/services-impl/src/main/java/it/geosolutions/fra2015/services/SurveyServiceImpl.java
+++ b/server/services-impl/src/main/java/it/geosolutions/fra2015/services/SurveyServiceImpl.java
@@ -546,7 +546,7 @@ public class SurveyServiceImpl implements SurveyService {
 					value.getContent());
 			values.add(compact);
 		}
-		List<TextValue> textValues = bulkLoader.loadAllTextValues(iso3);
+		List<TextValue> textValues = bulkLoader.loadTextNumericValues(iso3,questionNumber);
 		for (Value value : textValues) {
 			EntryItem item = value.getEntryItem();
 			CompactValue compact = new CompactValue(


### PR DESCRIPTION
This fix solve the regression introduced in [this commit](https://github.com/geosolutions-it/fra2015/commit/a7b63f4acd39876266eb296be26c3fc88301b9f0)

as can be seen [here](https://github.com/geosolutions-it/fra2015/commit/a7b63f4acd39876266eb296be26c3fc88301b9f0#diff-b449a74e3334e1e6f076cee70ae117d2R548) the text value are loaded **without** to be filtered with the question number so each question value load loads **all** the country text values.

In this way the [algorithm in SurveyController](https://github.com/geosolutions-it/fra2015/blob/master/server/mvc-controller/src/main/java/it/geosolutions/fra2015/mvc/controller/SurveyController.java#L193) selects all the text values that are not related to the current working question as they would be values that must be deleted (see [this method](https://github.com/geosolutions-it/fra2015/blob/master/server/mvc-controller/src/main/java/it/geosolutions/fra2015/mvc/controller/SurveyController.java#L301) ) and thus it delete them.

This fix has been tested and it solves the highlighted production bug **but since it modify the implementation of one of the core services** this pull request must be discussed and tested by other team members since it must be deployed in production asap.