### PR TITLE
Removed FAO logo from the first page

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/xsl/countryReport.xsl
+++ b/webapp/src/main/webapp/WEB-INF/xsl/countryReport.xsl
@@ -109,11 +109,6 @@
 				margin-top="150pt">
 				<xsl:value-of select='//title' />
 			</fo:block>
-			<fo:block text-align="center" margin-top="100pt">
-				<fo:external-graphic src="url('img/faologo.png')"
-					width="50pt" height="50pt" content-width="scale-to-fit"
-					content-height="scale-to-fit" />
-			</fo:block>
 			<fo:block text-align="center" font-size="24pt" font-weight="bold">
 				Forestry Department
 			</fo:block>

--- a/webapp/src/main/webapp/WEB-INF/xsl/countryReportFull.xsl
+++ b/webapp/src/main/webapp/WEB-INF/xsl/countryReportFull.xsl
@@ -109,11 +109,6 @@
 				margin-top="150pt">
 				<xsl:value-of select='//title' />
 			</fo:block>
-			<fo:block text-align="center" margin-top="100pt">
-				<fo:external-graphic src="url('img/faologo.png')"
-					width="50pt" height="50pt" content-width="scale-to-fit"
-					content-height="scale-to-fit" />
-			</fo:block>
 			<fo:block text-align="center" font-size="24pt" font-weight="bold">
 				Forestry Department
 			</fo:block>

--- a/webapp/src/main/webapp/WEB-INF/xsl/feedbackReport.xsl
+++ b/webapp/src/main/webapp/WEB-INF/xsl/feedbackReport.xsl
@@ -95,11 +95,6 @@
         <fo:block text-align="center" font-size="12pt" margin-top="10pt">
           <xsl:value-of select="//div[@id='userName']" /> feedback <xsl:value-of select="//div[@id='profileName']" /> summary on <xsl:value-of select="//div[@id='currentDate']" />
         </fo:block>
-      <fo:block text-align="center" margin-top="100pt">
-        <fo:external-graphic src="url('/img/faologo.png')"
-          width="50pt" height="50pt" content-width="scale-to-fit"
-          content-height="scale-to-fit" />
-      </fo:block>
       <fo:block text-align="center" font-size="24pt" font-weight="bold">
         Forestry Department
       </fo:block>


### PR DESCRIPTION
This pull request close #431

It has been tested:

* user **admin** printing a group of countries (exluding empty fields, including only cfqr, both)
* user **admin** printing a single country (exluding empty fields, including only cfqr, both)
* user **AFG** printing with all the options (exluding empty fields, including only cfqr, including reviewers comments, all the possible combinations of the latter 3 options)

**REMARKS**

* In the second page the logo **is still visible**
* the **feedbackReport.xsl** seems unused... should we delete it? anyway the lofo has been removed also from that XSL
* the **countryReport.xsl** and **countryReportFull.xsl** have ambiguous names the first is for CFQR and the latter is used both in batch and single country print